### PR TITLE
Let ListBucketWithRetry be able to retry

### DIFF
--- a/gpAux/extensions/gps3ext/include/s3interface.h
+++ b/gpAux/extensions/gps3ext/include/s3interface.h
@@ -26,7 +26,7 @@ class S3Service : public S3Interface {
    private:
     string getUrl(const string& prefix, const string& schema, const string& host,
                   const string& bucket, const string& marker);
-    void parseBucketXML(ListBucketResult* result, xmlNode* root_element, string& marker);
+    bool parseBucketXML(ListBucketResult* result, xmlNode* root_element, string& marker);
     xmlParserCtxtPtr getBucketXML(const string& region, const string& url, const string& prefix,
                                   const S3Credential& cred, const string& marker);
     bool checkAndParseBucketXML(ListBucketResult* result, xmlParserCtxtPtr xmlcontext,

--- a/gpAux/extensions/gps3ext/src/s3bucket_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3bucket_reader.cpp
@@ -120,8 +120,17 @@ ListBucketResult *S3BucketReader::listBucketWithRetry(int retries) {
     CHECK_OR_DIE(this->s3interface != NULL);
 
     while (retries--) {
-        ListBucketResult *result = this->s3interface->ListBucket(
-            this->schema, this->region, this->bucket, this->prefix, this->cred);
+        ListBucketResult *result = NULL;
+        try {
+            result = this->s3interface->ListBucket(this->schema, this->region, this->bucket,
+                                                   this->prefix, this->cred);
+        } catch (std::runtime_error &error) {
+            S3WARN("Exception caught:%s", error.what());
+
+            // jump out the loop quietly and print remaining error
+            break;
+        }
+
         if (result != NULL) {
             return result;
         }

--- a/gpAux/extensions/gps3ext/src/s3interface.cpp
+++ b/gpAux/extensions/gps3ext/src/s3interface.cpp
@@ -132,13 +132,13 @@ bool S3Service::checkAndParseBucketXML(ListBucketResult *result, xmlParserCtxtPt
     }
 
     // parseBucketXML will set marker for next round.
-    this->parseBucketXML(result, rootElement, marker);
-
-    return true;
+    return this->parseBucketXML(result, rootElement, marker);
 }
 
-void S3Service::parseBucketXML(ListBucketResult *result, xmlNode *root_element, string &marker) {
-    CHECK_OR_DIE((result != NULL && root_element != NULL));
+bool S3Service::parseBucketXML(ListBucketResult *result, xmlNode *root_element, string &marker) {
+    if (result == NULL || root_element == NULL) {
+        return false;
+    }
 
     xmlNodePtr cur;
     bool is_truncated = false;
@@ -226,7 +226,7 @@ void S3Service::parseBucketXML(ListBucketResult *result, xmlNode *root_element, 
         xmlFree(key);
     }
 
-    return;
+    return true;
 }
 
 // ListBucket list all keys in given bucket with given prefix.


### PR DESCRIPTION
ListBucket() should not throw exception if the error can be resolved by retrying,
otherwise ListBucketWithRetry() could not retry. Besides, we also add try/catch
within ListBucketWithRetry() to gurrantee the exception-process coverage and print
out error message in following codes.

Co-authored by Haozhou Wang and Kuien Liu