### PR TITLE
Support run a subset of cases using gtest_filter:

### DIFF
--- a/gpAux/extensions/gps3ext/Makefile.others
+++ b/gpAux/extensions/gps3ext/Makefile.others
@@ -19,6 +19,7 @@ all: test
 TEST_SRC_FILES = test/s3conf_test.cpp test/s3utils_test.cpp test/s3common_test.cpp test/s3log_test.cpp test/s3url_parser_test.cpp test/s3http_headers_test.cpp test/s3bucket_reader_test.cpp test/s3interface_test.cpp test/s3restful_service_test.cpp test/uncompress_reader_test.cpp test/s3key_reader_test.cpp
 TEST_OBJS = $(TEST_SRC_FILES:.cpp=.o)
 TEST_APP = s3test
+gtest_filter ?= *
 
 DEP_FILES := $(patsubst %.cpp,%.d,$(TEST_SRC_FILES))
 -include $(DEP_FILES)
@@ -51,7 +52,7 @@ $(TEST_APP): $(TEST_OBJS) gtest_main.a
 
 test: $(TEST_APP)
 	-rm -rf *.gcda *.gcov test/*.gcda test/*.gcov
-	-@./$(TEST_APP)
+	@-./$(TEST_APP) --gtest_filter=$(gtest_filter)
 
 coverage: test
 	@gcov $(TEST_SRC_FILES) | grep -A 1 "src/.*.cpp"


### PR DESCRIPTION
Run all cases:
    $ make test

Run a subset cases using pattern match, run all tests in S3KeyReaderTest suite:
    $ make test gfilter_test=S3KeyReaderTest.*

Run a subset cases using pattern match, run all MTRead tests:
    $ make test gtest_filter=S3KeyReaderTest.MTReadWith*