### PR TITLE
Fix the exception bug in S3Service::fetchData()

### DIFF
--- a/gpAux/extensions/gps3ext/test/s3interface_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3interface_test.cpp
@@ -312,10 +312,10 @@ TEST_F(S3ServiceTest, fetchDataFailedResponse) {
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
     char buffer[100];
 
-    EXPECT_THROW(s3service->fetchData(
-                     0, buffer, 100,
-                     "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever", region, cred),
-                 std::runtime_error);
+    EXPECT_EQ(0,
+              s3service->fetchData(0, buffer, 100,
+                                   "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever",
+                                   region, cred));
 }
 
 TEST_F(S3ServiceTest, fetchDataPartialResponse) {
@@ -325,10 +325,10 @@ TEST_F(S3ServiceTest, fetchDataPartialResponse) {
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
     char buffer[100];
 
-    EXPECT_THROW(s3service->fetchData(
-                     0, buffer, 100,
-                     "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever", region, cred),
-                 std::runtime_error);
+    EXPECT_EQ(0,
+              s3service->fetchData(0, buffer, 100,
+                                   "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever",
+                                   region, cred));
 }
 
 TEST_F(S3ServiceTest, checkItsGzipCompressed) {


### PR DESCRIPTION
When a FAIL response from KeyReader is given, an exception
will be throw from S3Service::fetchData(), and this exception
will crash the downloader threads and process (core dumped).

We replace exception with error return, and it will be handled
by the caller.

Co-authored:
  Peifeng Qiu <pqiu@pivotal.io>
  Haozhou Wang <hawang@pivotal.io>
  Kuien Liu <kliu@pivotal.io>