### PR TITLE
fix C++ 98 compliance issues when compiling in redhat 7 with gcc

### DIFF
--- a/gpAux/extensions/gps3ext/include/restful_service.h
+++ b/gpAux/extensions/gps3ext/include/restful_service.h
@@ -57,7 +57,9 @@ class Response {
 
     void clearBuffer() {
         buffer.clear();
-        buffer.shrink_to_fit();
+
+        // shrink to fit is added in C++11
+        // buffer.shrink_to_fit();
     }
 
    private:

--- a/gpAux/extensions/gps3ext/include/s3interface.h
+++ b/gpAux/extensions/gps3ext/include/s3interface.h
@@ -1,6 +1,9 @@
 #ifndef INCLUDE_S3INTERFACE_H_
 #define INCLUDE_S3INTERFACE_H_
 
+// need to include stdexcept to use std::runtime_error
+#include <stdexcept>
+
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 

--- a/gpAux/extensions/gps3ext/include/s3key_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3key_reader.h
@@ -67,6 +67,10 @@ class ChunkBuffer {
 
     ~ChunkBuffer();
 
+    // In C++98, if a class has reference member,
+    // then it can't be copy assigned by default, we need to implement operator= explicitly.
+    ChunkBuffer& operator=(const ChunkBuffer& other);
+
     bool isEOF() {
         return this->eof;
     }

--- a/gpAux/extensions/gps3ext/src/s3key_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3key_reader.cpp
@@ -46,6 +46,17 @@ ChunkBuffer::~ChunkBuffer() {
     this->destroy();
 }
 
+ChunkBuffer& ChunkBuffer::operator=(const ChunkBuffer& other) {
+    this->sourceUrl = other.sourceUrl;
+    this->eof = other.eof;
+    this->status = other.status;
+    this->curFileOffset = other.curFileOffset;
+    this->curChunkOffset = other.curChunkOffset;
+    this->chunkDataSize = other.chunkDataSize;
+
+    return *this;
+}
+
 // Copy constructor will copy members, but chunkData must not be initialized before copy.
 // otherwise when worked with vector it will be freed twice.
 void ChunkBuffer::init() {

--- a/gpAux/extensions/gps3ext/test/gpreader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/gpreader_test.cpp
@@ -154,9 +154,18 @@ class MockS3RESTfulServiceForMultiThreads : public MockS3RESTfulService {
         string rangeNumber = range.substr(index + 1);
         index = rangeNumber.find("-");
 
-        int begin = std::stoi(rangeNumber.substr(0, index));
-        int end =
-            index == rangeNumber.length() ? data.size() : std::stoi(rangeNumber.substr(index + 1));
+        int begin, end;
+        if (index > 0) {
+            sscanf(rangeNumber.substr(0, index).c_str(), "%d", &begin);
+        } else {
+            begin = 0;
+        }
+
+        if (rangeNumber.empty()) {
+            end = data.size();
+        } else {
+            sscanf(rangeNumber.substr(index + 1).c_str(), "%d", &end);
+        }
 
         vector<uint8_t> responseData(data.begin() + begin, data.begin() + end + 1);
 

--- a/gpAux/extensions/gps3ext/test/gpreader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/gpreader_test.cpp
@@ -154,6 +154,7 @@ class MockS3RESTfulServiceForMultiThreads : public MockS3RESTfulService {
         string rangeNumber = range.substr(index + 1);
         index = rangeNumber.find("-");
 
+        // stoi is not available in C++98, use sscanf as workaround.
         int begin, end;
         if (index > 0) {
             sscanf(rangeNumber.substr(0, index).c_str(), "%d", &begin);


### PR DESCRIPTION
The clang in mac does not check the -std=c++98 flag strictly.
Hence when compiling on the other platform like redhat 7 (using gcc),
the source code may not be compiled correctly. The compiling errors have
been fixed and the tests have been passed on redhat7 using c++98.

1. std::vector<T>::shrink_to_fit is added in C++11.
2. need to include <stdexcept> to use std::runtime_error.
3. In C++98, if a class has reference member, then it can't be copy assigned by default,
   we need to implement operator= explicitly.
4. stoi is added in C++11.

Signed-off-by: Haozhou Wang <hawang@pivotal.io>