### PR TITLE
Link uncompression reader into s3 module.

### DIFF
--- a/gpAux/extensions/gps3ext/include/gpreader.h
+++ b/gpAux/extensions/gps3ext/include/gpreader.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "s3bucket_reader.h"
+#include "s3common_reader.h"
 #include "s3interface.h"
 #include "s3key_reader.h"
 
@@ -28,7 +29,8 @@ class GPReader : public Reader {
 
    protected:
     S3BucketReader bucketReader;
-    S3KeyReader keyReader;
+    S3CommonReader commonReader;
+    UncompressReader uncomressReader;
     S3RESTfulService restfulService;
 
     S3Service s3service;

--- a/gpAux/extensions/gps3ext/include/makefile.inc
+++ b/gpAux/extensions/gps3ext/include/makefile.inc
@@ -1,4 +1,4 @@
-COMMON_OBJS = s3conf.o s3common.o s3utils.o s3log.o s3url_parser.o s3http_headers.o s3interface.o s3restful_service.o uncompress_reader.o s3key_reader.o s3bucket_reader.o gpreader.o
+COMMON_OBJS = s3conf.o s3common.o s3utils.o s3log.o s3url_parser.o s3http_headers.o s3interface.o s3restful_service.o uncompress_reader.o s3key_reader.o s3bucket_reader.o gpreader.o s3common_reader.o
 
 COMMON_LINK_OPTIONS = -lstdc++ -lxml2 -lpthread -lcrypto -lcurl -lz
 

--- a/gpAux/extensions/gps3ext/include/s3common_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3common_reader.h
@@ -1,0 +1,40 @@
+/*
+ * s3common_reader.h
+ *
+ *  Created on: Jun 21, 2016
+ *      Author: pqiu
+ */
+
+#ifndef INCLUDE_S3COMMON_READER_H_
+#define INCLUDE_S3COMMON_READER_H_
+
+#include "s3key_reader.h"
+#include "uncompress_reader.h"
+
+class S3CommonReader : public Reader {
+   public:
+    S3CommonReader();
+    virtual ~S3CommonReader();
+
+    virtual void open(const ReaderParams& params);
+
+    // read() attempts to read up to count bytes into the buffer starting at
+    // buffer.
+    // Return 0 if EOF. Throw exception if encounters errors.
+    virtual uint64_t read(char* buf, uint64_t count);
+
+    // This should be reentrant, has no side effects when called multiple times.
+    virtual void close();
+
+    void setS3service(S3Interface* s3service) {
+        this->s3service = s3service;
+    }
+
+   protected:
+    Reader* upstreamReader;
+    S3Interface* s3service;
+    S3KeyReader keyReader;
+    UncompressReader uncompressReader;
+};
+
+#endif /* INCLUDE_S3COMMON_READER_H_ */

--- a/gpAux/extensions/gps3ext/include/s3common_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3common_reader.h
@@ -1,10 +1,3 @@
-/*
- * s3common_reader.h
- *
- *  Created on: Jun 21, 2016
- *      Author: pqiu
- */
-
 #ifndef INCLUDE_S3COMMON_READER_H_
 #define INCLUDE_S3COMMON_READER_H_
 

--- a/gpAux/extensions/gps3ext/include/s3interface.h
+++ b/gpAux/extensions/gps3ext/include/s3interface.h
@@ -64,6 +64,11 @@ class S3Interface {
                                const string& region, const S3Credential& cred) {
         throw std::runtime_error("Default implementation must not be called.");
     }
+
+    virtual S3CompressionType checkCompressionType(const string& keyUrl, const string& region,
+                                                   const S3Credential& cred) {
+        throw std::runtime_error("Default implementation must not be called.");
+    }
 };
 
 class S3Service : public S3Interface {

--- a/gpAux/extensions/gps3ext/include/uncompress_reader.h
+++ b/gpAux/extensions/gps3ext/include/uncompress_reader.h
@@ -16,7 +16,7 @@
 #include "reader.h"
 
 // 256K by default
-unsigned int S3_ZIP_CHUNKSIZE = 256 * 1024;
+extern unsigned int S3_ZIP_CHUNKSIZE;
 
 class UncompressReader : public Reader {
    public:

--- a/gpAux/extensions/gps3ext/src/gpreader.cpp
+++ b/gpAux/extensions/gps3ext/src/gpreader.cpp
@@ -81,8 +81,8 @@ void GPReader::constructReaderParam(const string& url) {
 void GPReader::open(const ReaderParams& params) {
     this->s3service.setRESTfulService(this->restfulServicePtr);
     this->bucketReader.setS3interface(&this->s3service);
-    this->keyReader.setS3interface(&this->s3service);
-    this->bucketReader.setUpstreamReader(&this->keyReader);
+    this->bucketReader.setUpstreamReader(&this->commonReader);
+    this->commonReader.setS3service(&this->s3service);
     this->bucketReader.open(this->params);
 }
 

--- a/gpAux/extensions/gps3ext/src/s3common_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3common_reader.cpp
@@ -1,0 +1,45 @@
+/*
+ * s3common_reader.cpp
+ *
+ *  Created on: Jun 21, 2016
+ *      Author: pqiu
+ */
+
+#include "s3common_reader.h"
+#include "s3macros.h"
+
+S3CommonReader::S3CommonReader() {
+}
+
+S3CommonReader::~S3CommonReader() {
+}
+
+void S3CommonReader::open(const ReaderParams &params) {
+    this->keyReader.setS3interface(s3service);
+    S3CompressionType compressionType =
+        s3service->checkCompressionType(params.getKeyUrl(), params.getRegion(), params.getCred());
+    switch (compressionType) {
+        case S3_COMPRESSION_GZIP:
+            this->upstreamReader = &this->uncompressReader;
+            this->uncompressReader.setReader(&this->keyReader);
+            break;
+        case S3_COMPRESSION_PLAIN:
+            this->upstreamReader = &this->keyReader;
+            break;
+        default:
+            CHECK_OR_DIE_MSG(false, "%s", "unknown file type");
+    };
+    this->upstreamReader->open(params);
+}
+
+// read() attempts to read up to count bytes into the buffer starting at
+// buffer.
+// Return 0 if EOF. Throw exception if encounters errors.
+uint64_t S3CommonReader::read(char *buf, uint64_t count) {
+    return this->upstreamReader->read(buf, count);
+}
+
+// This should be reentrant, has no side effects when called multiple times.
+void S3CommonReader::close() {
+    this->upstreamReader->close();
+}

--- a/gpAux/extensions/gps3ext/src/s3common_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3common_reader.cpp
@@ -1,10 +1,3 @@
-/*
- * s3common_reader.cpp
- *
- *  Created on: Jun 21, 2016
- *      Author: pqiu
- */
-
 #include "s3common_reader.h"
 #include "s3macros.h"
 

--- a/gpAux/extensions/gps3ext/src/s3interface.cpp
+++ b/gpAux/extensions/gps3ext/src/s3interface.cpp
@@ -336,6 +336,10 @@ S3CompressionType S3Service::checkCompressionType(const string &keyUrl, const st
     Response resp = service->get(keyUrl, headers, params);
     if (resp.getStatus() == RESPONSE_OK) {
         vector<uint8_t> &responseData = resp.getRawData();
+        if (responseData.size() < S3_MAGIC_BYTES_NUM) {
+            return S3_COMPRESSION_PLAIN;
+        }
+
         CHECK_OR_DIE_MSG(responseData.size() == S3_MAGIC_BYTES_NUM, "%s",
                          "Response is not fully received.");
 

--- a/gpAux/extensions/gps3ext/src/s3key_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/s3key_reader.cpp
@@ -209,6 +209,8 @@ void S3KeyReader::open(const ReaderParams& params) {
     this->offsetMgr.setKeySize(params.getKeySize());
     this->offsetMgr.setChunkSize(params.getChunkSize());
 
+    CHECK_OR_DIE_MSG(params.getChunkSize() > 0, "%s", "chunk size must be greater than zero");
+
     for (uint64_t i = 0; i < this->numOfChunks; i++) {
         // when vector reallocate memory, it will copy object.
         // chunkData must be initialized after all copy.

--- a/gpAux/extensions/gps3ext/src/uncompress_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/uncompress_reader.cpp
@@ -118,8 +118,8 @@ void UncompressReader::uncompress() {
         this->zstream.next_out = (Byte *)this->out;
     }
 
-    S3DEBUG("Before decompress: avail_in = %u, avail_out = %u, total_in = %u, total_out = %u",
-            zstream.avail_in, zstream.avail_out, zstream.total_in, zstream.total_out);
+    // S3DEBUG("Before decompress: avail_in = %u, avail_out = %u, total_in = %u, total_out = %u",
+    //      zstream.avail_in, zstream.avail_out, zstream.total_in, zstream.total_out);
 
     int status = inflate(&this->zstream, Z_NO_FLUSH);
     if (status == Z_STREAM_END) {
@@ -129,8 +129,8 @@ void UncompressReader::uncompress() {
         CHECK_OR_DIE_MSG(false, "failed to decompress data: %d", status);
     }
 
-    S3DEBUG("After decompress: avail_in = %u, avail_out = %u, total_in = %u, total_out = %u",
-            zstream.avail_in, zstream.avail_out, zstream.total_in, zstream.total_out);
+    // S3DEBUG("After decompress: avail_in = %u, avail_out = %u, total_in = %u, total_out = %u",
+    //     zstream.avail_in, zstream.avail_out, zstream.total_in, zstream.total_out);
 
     return;
 }

--- a/gpAux/extensions/gps3ext/src/uncompress_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/uncompress_reader.cpp
@@ -6,6 +6,8 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+unsigned int S3_ZIP_CHUNKSIZE = 256 * 1024;
+
 UncompressReader::UncompressReader() {
     this->reader = NULL;
     this->in = new char[S3_ZIP_CHUNKSIZE];
@@ -47,6 +49,8 @@ void UncompressReader::open(const ReaderParams &params) {
     // 47 is the number of windows bits, to make sure zlib could recognize and decode gzip stream.
     int ret = inflateInit2(&zstream, 47);
     CHECK_OR_DIE_MSG(ret == Z_OK, "%s", "failed to initialize zlib library");
+
+    this->reader->open(params);
 }
 
 uint64_t UncompressReader::read(char *buf, uint64_t bufSize) {
@@ -133,4 +137,5 @@ void UncompressReader::uncompress() {
 
 void UncompressReader::close() {
     inflateEnd(&zstream);
+    this->reader->close();
 }

--- a/gpAux/extensions/gps3ext/src/uncompress_reader.cpp
+++ b/gpAux/extensions/gps3ext/src/uncompress_reader.cpp
@@ -6,7 +6,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-unsigned int S3_ZIP_CHUNKSIZE = 256 * 1024;
+unsigned int S3_ZIP_CHUNKSIZE = 1024 * 1024 * 2;
 
 UncompressReader::UncompressReader() {
     this->reader = NULL;
@@ -60,8 +60,9 @@ uint64_t UncompressReader::read(char *buf, uint64_t bufSize) {
     bool readFinished = false;
 
     do {
-        S3DEBUG("has = %" PRIu64 ", offset = %d, chunksize = %u, avail_out = %u, count = %" PRIu64,
-                remainingOutLen, outOffset, S3_ZIP_CHUNKSIZE, this->zstream.avail_out, bufSize);
+        // S3DEBUG("has = %" PRIu64 ", offset = %d, chunksize = %u, avail_out = %u, count = %"
+        // PRIu64,
+        //     remainingOutLen, outOffset, S3_ZIP_CHUNKSIZE, this->zstream.avail_out, bufSize);
 
         if (this->outOffset < (S3_ZIP_CHUNKSIZE - this->zstream.avail_out)) {
             // Read remaining data in out buffer uncompressed last time.

--- a/gpAux/extensions/gps3ext/test/gpreader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/gpreader_test.cpp
@@ -120,6 +120,9 @@ TEST_F(GPReaderTest, ReadSmallData) {
 
     EXPECT_CALL(mockRestfulService, get(_, _, _))
         .WillOnce(Return(listBucketResponse))
+        // first 4 bytes is retrieved once for format detection.
+        .WillOnce(Return(keyReaderResponse))
+        // whole file content
         .WillOnce(Return(keyReaderResponse));
 
     ReaderParams params;

--- a/gpAux/extensions/gps3ext/test/mock_classes.h
+++ b/gpAux/extensions/gps3ext/test/mock_classes.h
@@ -21,6 +21,9 @@ class MockS3Interface : public S3Interface {
     MOCK_METHOD6(fetchData,
                  uint64_t(uint64_t offset, char *data, uint64_t len, const string &sourceUrl,
                           const string &region, const S3Credential &cred));
+
+    MOCK_METHOD3(checkCompressionType, S3CompressionType(const string& keyUrl, const string& region,
+                                           const S3Credential& cred));
 };
 
 

--- a/gpAux/extensions/gps3ext/test/s3common_reader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3common_reader_test.cpp
@@ -1,9 +1,3 @@
-/*
- * s3common_reader_test.cpp
- *
- *  Created on: Jun 21, 2016
- *      Author: pqiu
- */
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -42,14 +36,6 @@ class S3CommonReaderTest : public ::testing::Test, public S3CommonReader {
     virtual void TearDown() {
     }
 
-    void setBufReaderByRawData(const void *input, int len, Byte *compressionBuff,
-                               uLong compressedLen) {
-        int err = compress(compressionBuff, &compressedLen, (const Bytef *)input, len);
-        if (err != Z_OK) {
-            S3DEBUG("failed to compress sample data");
-        }
-    }
-
     MockS3InterfaceForCompressionRead mockS3Interface;
 };
 
@@ -82,7 +68,7 @@ TEST_F(S3CommonReaderTest, OpenPlain) {
 TEST_F(S3CommonReaderTest, ReadGZip) {
     Byte compressionBuff[0x100];
     uLong compressedLen = sizeof(compressionBuff);
-    const char hello[] = "Go IPO, Pivotal! Go Go Go!!!";
+    const char hello[] = "The quick brown fox jumps over the lazy dog";
 
     compress(compressionBuff, &compressedLen, (const Bytef *)hello, sizeof(hello));
 
@@ -103,5 +89,5 @@ TEST_F(S3CommonReaderTest, ReadGZip) {
 
     EXPECT_EQ(sizeof(hello), this->upstreamReader->read(result, sizeof(result)));
     EXPECT_EQ(0, this->upstreamReader->read(result, sizeof(result)));
-    EXPECT_EQ(0, strcmp(result, hello));
+    EXPECT_EQ(0, memcmp(result, hello, sizeof(hello)));
 }

--- a/gpAux/extensions/gps3ext/test/s3common_reader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3common_reader_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * s3common_reader_test.cpp
+ *
+ *  Created on: Jun 21, 2016
+ *      Author: pqiu
+ */
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "mock_classes.h"
+#include "s3common_reader.cpp"
+#include "uncompress_reader.h"
+
+using ::testing::AtLeast;
+using ::testing::Return;
+using ::testing::Invoke;
+using ::testing::Throw;
+using ::testing::_;
+
+class MockS3InterfaceForCompressionRead : public MockS3Interface {
+   public:
+    void setData(Byte *rawData, uLong len) {
+        data.insert(data.begin(), rawData, rawData + len);
+    }
+    uint64_t mockFetchData(uint64_t offset, char *data, uint64_t len, const string &sourceUrl,
+                           const string &region, const S3Credential &cred) {
+        memcpy(data, this->data.data(), this->data.size());
+        return this->data.size();
+    }
+
+    vector<uint8_t> data;
+};
+
+class S3CommonReaderTest : public ::testing::Test, public S3CommonReader {
+   protected:
+    // Remember that SetUp() is run immediately before a test starts.
+    virtual void SetUp() {
+        this->setS3service(&mockS3Interface);
+    }
+
+    // TearDown() is invoked immediately after a test finishes.
+    virtual void TearDown() {
+    }
+
+    void setBufReaderByRawData(const void *input, int len, Byte *compressionBuff,
+                               uLong compressedLen) {
+        int err = compress(compressionBuff, &compressedLen, (const Bytef *)input, len);
+        if (err != Z_OK) {
+            S3DEBUG("failed to compress sample data");
+        }
+    }
+
+    MockS3InterfaceForCompressionRead mockS3Interface;
+};
+
+TEST_F(S3CommonReaderTest, OpenGZip) {
+    // test case for: the file format is gzip, then uncompressReader should be called
+    EXPECT_CALL(mockS3Interface, checkCompressionType(_, _, _))
+        .WillOnce(Return(S3_COMPRESSION_GZIP));
+    ReaderParams params;
+    params.setNumOfChunks(1);
+    params.setChunkSize(1024 * 1024 * 2);
+    this->open(params);
+
+    ASSERT_EQ(this->upstreamReader, &this->uncompressReader);
+    ASSERT_TRUE(NULL != dynamic_cast<UncompressReader *>(this->upstreamReader));
+}
+
+TEST_F(S3CommonReaderTest, OpenPlain) {
+    // test case for: the file format is gzip, then S3keyReader should be called
+    EXPECT_CALL(mockS3Interface, checkCompressionType(_, _, _))
+        .WillOnce(Return(S3_COMPRESSION_PLAIN));
+    ReaderParams params;
+    params.setNumOfChunks(1);
+    params.setChunkSize(1024 * 1024 * 2);
+    this->open(params);
+
+    ASSERT_EQ(this->upstreamReader, &this->keyReader);
+    ASSERT_TRUE(NULL != dynamic_cast<S3KeyReader *>(this->upstreamReader));
+}
+
+TEST_F(S3CommonReaderTest, ReadGZip) {
+    Byte compressionBuff[0x100];
+    uLong compressedLen = sizeof(compressionBuff);
+    const char hello[] = "Go IPO, Pivotal! Go Go Go!!!";
+
+    compress(compressionBuff, &compressedLen, (const Bytef *)hello, sizeof(hello));
+
+    mockS3Interface.setData(compressionBuff, compressedLen);
+
+    EXPECT_CALL(mockS3Interface, checkCompressionType(_, _, _))
+        .WillOnce(Return(S3_COMPRESSION_GZIP));
+
+    EXPECT_CALL(mockS3Interface, fetchData(_, _, _, _, _, _))
+        .WillOnce(Invoke(&mockS3Interface, &MockS3InterfaceForCompressionRead::mockFetchData));
+
+    char result[0x100];
+    ReaderParams params;
+    params.setNumOfChunks(1);
+    params.setChunkSize(1024 * 1024 * 2);
+    params.setKeySize(compressedLen);
+    this->open(params);
+
+    EXPECT_EQ(sizeof(hello), this->upstreamReader->read(result, sizeof(result)));
+    EXPECT_EQ(0, this->upstreamReader->read(result, sizeof(result)));
+    EXPECT_EQ(0, strcmp(result, hello));
+}

--- a/gpAux/extensions/gps3ext/test/s3interface_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3interface_test.cpp
@@ -271,6 +271,19 @@ TEST_F(S3ServiceTest, fetchDataPartialResponse) {
                                    region, cred));
 }
 
+TEST_F(S3ServiceTest, checkSmallFile) {
+    vector<uint8_t> raw;
+    raw.resize(2);
+    raw[0] = 0x1f;
+    raw[1] = 0x8b;
+    Response response(RESPONSE_OK, raw);
+    EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
+
+    EXPECT_EQ(S3_COMPRESSION_PLAIN,
+              s3service->checkCompressionType(
+                  "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever", region, cred));
+}
+
 TEST_F(S3ServiceTest, checkItsGzipCompressed) {
     vector<uint8_t> raw;
     raw.resize(4);

--- a/gpAux/extensions/gps3ext/test/uncompress_reader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/uncompress_reader_test.cpp
@@ -54,8 +54,9 @@ class UncompressReaderTest : public testing::Test {
    protected:
     // Remember that SetUp() is run immediately before a test starts.
     virtual void SetUp() {
-        uncompressReader.open(params);
+        // need to setup upstreamReader before open.
         uncompressReader.setReader(&bufReader);
+        uncompressReader.open(params);
     }
 
     // TearDown() is invoked immediately after a test finishes.

--- a/gpAux/extensions/gps3ext/test/uncompress_reader_test.cpp
+++ b/gpAux/extensions/gps3ext/test/uncompress_reader_test.cpp
@@ -95,7 +95,7 @@ TEST_F(UncompressReaderTest, AbleToUncompressEmptyData) {
 
 TEST_F(UncompressReaderTest, AbleToUncompressSmallCompressedData) {
     // 1. compressed data to uncompress
-    const char hello[] = "Go IPO, Pivotal! Go Go Go!!!";
+    const char hello[] = "The quick brown fox jumps over the lazy dog";
     setBufReaderByRawData(hello, sizeof(hello));
 
     // 2. call API


### PR DESCRIPTION
1. add s3common_reader to detect the format of file
   if the file is compressed call uncompressReader
   otherwise call S3KeyReader directly.
2. add checkCompressionType() into S3Interface.
3. fix a bug if the file size is less than S3_MAGIC_BYTES_NUM
   and add a unit test
4. fix a bug if chunkSize is zero.
5. add unit tests

Signed-off-by: Haozhou Wang <hawang@pivotal.io>