### PR TITLE
Refactor error message handling, able to propagate error back to gpdb console

### DIFF
--- a/gpAux/extensions/gps3ext/include/gpreader.h
+++ b/gpAux/extensions/gps3ext/include/gpreader.h
@@ -8,6 +8,8 @@
 #include "s3interface.h"
 #include "s3key_reader.h"
 
+extern string gpReaderErrorMessage;
+
 class GPReader : public Reader {
    public:
     GPReader(const string &url);

--- a/gpAux/extensions/gps3ext/include/s3key_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3key_reader.h
@@ -74,69 +74,7 @@ enum ChunkStatus {
     ReadyToFill,
 };
 
-class ChunkBuffer {
-   public:
-    ChunkBuffer(const string& url, OffsetMgr& mgr, bool& sharedError, const S3Credential& cred,
-                const string& region);
-
-    ~ChunkBuffer();
-
-    // In C++98, if a class has reference member,
-    // then it can't be copy assigned by default, we need to implement operator= explicitly.
-    ChunkBuffer& operator=(const ChunkBuffer& other);
-
-    bool isEOF() {
-        return this->eof;
-    }
-
-    // Error is shared among all ChunkBuffers of a KeyReader.
-    bool isError() {
-        return this->sharedError;
-    }
-    void setError() {
-        this->sharedError = true;
-    }
-
-    uint64_t read(char* buf, uint64_t len);
-    uint64_t fill();
-
-    void setS3interface(S3Interface* s3) {
-        this->s3interface = s3;
-    }
-
-    void init();
-    void destroy();
-
-    const pthread_cond_t* getStatCond() const {
-        return &stat_cond;
-    }
-
-    void setStatus(ChunkStatus status) {
-        this->status = status;
-    }
-
-   protected:
-    string sourceUrl;
-
-   private:
-    bool eof;
-    bool& sharedError;
-
-    ChunkStatus status;
-
-    pthread_mutex_t stat_mutex;
-    pthread_cond_t stat_cond;
-
-    uint64_t curFileOffset;
-    uint64_t curChunkOffset;
-    uint64_t chunkDataSize;
-    char* chunkData;
-    OffsetMgr& offsetMgr;
-    const S3Credential& credential;
-    const string& region;
-
-    S3Interface* s3interface;
-};
+class ChunkBuffer;
 
 class S3KeyReader : public Reader {
    public:
@@ -146,8 +84,10 @@ class S3KeyReader : public Reader {
           curReadingChunk(0),
           transferredKeyLen(0),
           s3interface(NULL) {
+        pthread_mutex_init(&this->mutex_key_reader, NULL);
     }
     virtual ~S3KeyReader() {
+        pthread_mutex_destroy(&this->mutex_key_reader);
     }
 
     void open(const ReaderParams& params);
@@ -170,6 +110,13 @@ class S3KeyReader : public Reader {
         return sharedError;
     }
 
+    void setSharedError(bool sharedError, string message) {
+        pthread_mutex_lock(&this->mutex_key_reader);
+        this->sharedErrorMessage = message;
+        this->sharedError = sharedError;
+        pthread_mutex_unlock(&this->mutex_key_reader);
+    }
+
     const vector<pthread_t>& getThreads() const {
         return threads;
     }
@@ -178,8 +125,24 @@ class S3KeyReader : public Reader {
         return transferredKeyLen;
     }
 
+    const S3Credential& getCredential() const {
+        return credential;
+    }
+
+    OffsetMgr& getOffsetMgr() {
+        return offsetMgr;
+    }
+
+    const string& getRegion() const {
+        return region;
+    }
+
    private:
+    pthread_mutex_t mutex_key_reader;
+
     bool sharedError;
+    string sharedErrorMessage;
+
     uint64_t numOfChunks;
     uint64_t curReadingChunk;
     uint64_t transferredKeyLen;
@@ -193,6 +156,69 @@ class S3KeyReader : public Reader {
     S3Interface* s3interface;
 
     void reset();
+};
+
+class ChunkBuffer {
+   public:
+    ChunkBuffer(const string& url, S3KeyReader& reader);
+
+    ~ChunkBuffer();
+
+    // In C++98, if a class has reference member,
+    // then it can't be copy assigned by default, we need to implement operator= explicitly.
+    ChunkBuffer& operator=(const ChunkBuffer& other);
+
+    bool isEOF() {
+        return this->eof;
+    }
+
+    // Error is shared among all ChunkBuffers of a KeyReader.
+    bool isError() {
+        return this->sharedKeyReader.isSharedError();
+    }
+
+    uint64_t read(char* buf, uint64_t len);
+    uint64_t fill();
+
+    void setS3interface(S3Interface* s3) {
+        this->s3interface = s3;
+    }
+
+    void init();
+    void destroy();
+
+    pthread_cond_t* getStatCond() {
+        return &stat_cond;
+    }
+
+    void setStatus(ChunkStatus status) {
+        this->status = status;
+    }
+
+    void setSharedError(bool sharedError, string message) {
+        this->sharedKeyReader.setSharedError(sharedError, message);
+    }
+
+   protected:
+    string sourceUrl;
+
+   private:
+    bool eof;
+
+    ChunkStatus status;
+
+    pthread_mutex_t stat_mutex;
+    pthread_cond_t stat_cond;
+
+    uint64_t curFileOffset;
+    uint64_t curChunkOffset;
+    uint64_t chunkDataSize;
+    char* chunkData;
+    OffsetMgr& offsetMgr;
+
+    S3Interface* s3interface;
+
+    S3KeyReader& sharedKeyReader;
 };
 
 #endif /* INCLUDE_S3KEYREADER_H_ */

--- a/gpAux/extensions/gps3ext/include/s3key_reader.h
+++ b/gpAux/extensions/gps3ext/include/s3key_reader.h
@@ -84,10 +84,10 @@ class S3KeyReader : public Reader {
           curReadingChunk(0),
           transferredKeyLen(0),
           s3interface(NULL) {
-        pthread_mutex_init(&this->mutex_key_reader, NULL);
+        pthread_mutex_init(&this->mutexErrorMessage, NULL);
     }
     virtual ~S3KeyReader() {
-        pthread_mutex_destroy(&this->mutex_key_reader);
+        pthread_mutex_destroy(&this->mutexErrorMessage);
     }
 
     void open(const ReaderParams& params);
@@ -111,10 +111,10 @@ class S3KeyReader : public Reader {
     }
 
     void setSharedError(bool sharedError, string message) {
-        pthread_mutex_lock(&this->mutex_key_reader);
+        pthread_mutex_lock(&this->mutexErrorMessage);
         this->sharedErrorMessage = message;
         this->sharedError = sharedError;
-        pthread_mutex_unlock(&this->mutex_key_reader);
+        pthread_mutex_unlock(&this->mutexErrorMessage);
     }
 
     const vector<pthread_t>& getThreads() const {
@@ -138,7 +138,7 @@ class S3KeyReader : public Reader {
     }
 
    private:
-    pthread_mutex_t mutex_key_reader;
+    pthread_mutex_t mutexErrorMessage;
 
     bool sharedError;
     string sharedErrorMessage;
@@ -188,7 +188,7 @@ class ChunkBuffer {
     void destroy();
 
     pthread_cond_t* getStatCond() {
-        return &stat_cond;
+        return &statusCondVar;
     }
 
     void setStatus(ChunkStatus status) {
@@ -207,8 +207,8 @@ class ChunkBuffer {
 
     ChunkStatus status;
 
-    pthread_mutex_t stat_mutex;
-    pthread_cond_t stat_cond;
+    pthread_mutex_t statusMutex;
+    pthread_cond_t statusCondVar;
 
     uint64_t curFileOffset;
     uint64_t curChunkOffset;

--- a/gpAux/extensions/gps3ext/src/gpreader.cpp
+++ b/gpAux/extensions/gps3ext/src/gpreader.cpp
@@ -61,6 +61,8 @@ int thread_cleanup(void) {
     return 1;
 }
 
+string gpReaderErrorMessage;
+
 GPReader::GPReader(const string& url) {
     constructReaderParam(url);
     restfulServicePtr = &restfulService;
@@ -101,7 +103,7 @@ void GPReader::close() {
 // invoked by s3_import(), need to be exception safe
 GPReader* reader_init(const char* url_with_options) {
     GPReader* reader = NULL;
-
+    gpReaderErrorMessage.clear();
     try {
         if (!url_with_options) {
             return NULL;
@@ -139,6 +141,7 @@ GPReader* reader_init(const char* url_with_options) {
             delete reader;
         }
         S3ERROR("reader_init caught an exception: %s, aborting", e.what());
+        gpReaderErrorMessage = e.what();
         return NULL;
     }
 }
@@ -160,6 +163,7 @@ bool reader_transfer_data(GPReader* reader, char* data_buf, int& data_len) {
         data_len = (int)read_len;
     } catch (std::exception& e) {
         S3ERROR("reader_transfer_data caught an exception: %s, aborting", e.what());
+        gpReaderErrorMessage = e.what();
         return false;
     }
 
@@ -179,6 +183,7 @@ bool reader_cleanup(GPReader** reader) {
         }
     } catch (std::exception& e) {
         S3ERROR("reader_cleanup caught an exception: %s, aborting", e.what());
+        gpReaderErrorMessage = e.what();
         result = false;
     }
 

--- a/gpAux/extensions/gps3ext/src/gps3ext.cpp
+++ b/gpAux/extensions/gps3ext/src/gps3ext.cpp
@@ -65,7 +65,8 @@ Datum s3_import(PG_FUNCTION_ARGS) {
         thread_cleanup();
 
         if (!reader_cleanup(&gpreader)) {
-            ereport(ERROR, (0, errmsg("Failed to cleanup S3 extention")));
+            ereport(ERROR, (0, errmsg("Failed to cleanup S3 extension: %s",
+                                      gpReaderErrorMessage.c_str())));
         }
 
         EXTPROTOCOL_SET_USER_CTX(fcinfo, NULL);
@@ -83,8 +84,8 @@ Datum s3_import(PG_FUNCTION_ARGS) {
         if (!gpreader) {
             ereport(ERROR, (0, errmsg("Failed to init S3 extension, segid = %d, "
                                       "segnum = %d, please check your "
-                                      "configurations and net connection",
-                                      s3ext_segid, s3ext_segnum)));
+                                      "configurations and net connection: %s",
+                                      s3ext_segid, s3ext_segnum, gpReaderErrorMessage.c_str())));
         }
 
         check_essential_config();
@@ -96,7 +97,8 @@ Datum s3_import(PG_FUNCTION_ARGS) {
     int32 data_len = EXTPROTOCOL_GET_DATALEN(fcinfo);
 
     if (!reader_transfer_data(gpreader, data_buf, data_len)) {
-        ereport(ERROR, (0, errmsg("s3_import: could not read data")));
+        ereport(ERROR,
+                (0, errmsg("s3_import: could not read data: %s", gpReaderErrorMessage.c_str())));
     }
     PG_RETURN_INT32(data_len);
 }

--- a/gpAux/extensions/gps3ext/src/s3interface.cpp
+++ b/gpAux/extensions/gps3ext/src/s3interface.cpp
@@ -309,12 +309,18 @@ uint64_t S3Service::fetchData(uint64_t offset, char *data, uint64_t len, const s
     } else if (resp.getStatus() == RESPONSE_ERROR) {
         xmlParserCtxtPtr xmlptr = getXMLContext(resp);
         parseXMLMessage(xmlptr);
+
         S3ERROR("Failed to fetch: %s, Response message: %s", sourceUrl.c_str(),
                 resp.getMessage().c_str());
+        CHECK_OR_DIE_MSG(false, "Failed to fetch: %s, Response message: %s", sourceUrl.c_str(),
+                         resp.getMessage().c_str());
+
         return 0;
     } else {
         S3ERROR("Failed to fetch: %s, Response message: %s", sourceUrl.c_str(),
                 resp.getMessage().c_str());
+        CHECK_OR_DIE_MSG(false, "Failed to fetch: %s, Response message: %s", sourceUrl.c_str(),
+                         resp.getMessage().c_str());
         return 0;
     }
 }

--- a/gpAux/extensions/gps3ext/test/s3interface_test.cpp
+++ b/gpAux/extensions/gps3ext/test/s3interface_test.cpp
@@ -252,10 +252,10 @@ TEST_F(S3ServiceTest, fetchDataFailedResponse) {
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
     char buffer[100];
 
-    EXPECT_EQ(0,
-              s3service->fetchData(0, buffer, 100,
-                                   "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever",
-                                   region, cred));
+    EXPECT_THROW(s3service->fetchData(
+                     0, buffer, 100,
+                     "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever", region, cred),
+                 std::runtime_error);
 }
 
 TEST_F(S3ServiceTest, fetchDataPartialResponse) {
@@ -352,7 +352,8 @@ TEST_F(S3ServiceTest, fetchDataWithResponseError) {
 
     EXPECT_CALL(mockRestfulService, get(_, _, _)).WillOnce(Return(response));
 
-    EXPECT_EQ(0, s3service->fetchData(
+    EXPECT_THROW(s3service->fetchData(
                      0, buf, 128, "https://s3-us-west-2.amazonaws.com/s3test.pivotal.io/whatever",
-                     region, cred));
+                     region, cred),
+                 std::runtime_error);
 }


### PR DESCRIPTION
1. add global error message variable to report to gpdb console.
2. add try/catch block around fetchData() call to catch error message.
3. refactor shared error mechanism between ChunkBuffers.
4. fix unit tests.

Signed-off-by: Haozhou Wang <hawang@pivotal.io>