### PR TITLE
Return the token and connection info via libpq

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -596,9 +596,9 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			// FIXME: Generate unique token here.
 			int32		token = 12345;
 
-			elog(WARNING, "Retrive token #%d", token);
-
 			SetGpToken(token);
+
+			SendRetrieveInfo();
 
 			if (exec_identity == GP_ROOT_SLICE &&
 				LocallyExecutingSliceIndex(estate) == 0)

--- a/src/include/cdb/cdbfifo.h
+++ b/src/include/cdb/cdbfifo.h
@@ -49,7 +49,7 @@ typedef EndPointDesc *EndPoint;
 extern Size EndPoint_ShmemSize(void);
 extern void EndPoint_ShmemInit(void);
 
-
+extern void SendRetrieveInfo(void);
 extern void SetGpToken(int32 token);
 extern void ClearGpToken(void);
 extern int32 GpToken(void);

--- a/src/include/libpq/pqformat.h
+++ b/src/include/libpq/pqformat.h
@@ -28,6 +28,7 @@ extern void pq_sendint64(StringInfo buf, int64 i);
 extern void pq_sendfloat4(StringInfo buf, float4 f);
 extern void pq_sendfloat8(StringInfo buf, float8 f);
 extern void pq_endmessage(StringInfo buf);
+extern int pq_flush(void);
 
 extern void pq_begintypsend(StringInfo buf);
 extern bytea *pq_endtypsend(StringInfo buf);

--- a/src/interfaces/libpq/fe-protocol3.c
+++ b/src/interfaces/libpq/fe-protocol3.c
@@ -442,6 +442,37 @@ pqParseInput3(PGconn *conn)
 					 * the COPY command.
 					 */
 					break;
+				case 'm':		/* Greenplum multi process fetch */
+					if (conn->result == NULL)
+					{
+						conn->result = PQmakeEmptyPGresult(conn, PGRES_TUPLES_OK);
+						if (!conn->result)
+							return;
+					}
+
+					if (pqGetInt(&conn->result->token, 4, conn))
+						return;
+
+#ifdef FRONTEND // TODO example of getting the info, remove this part before submiting the PR
+#include <lib/stringinfo.h>
+					PQExpBuffer msgbuf = malloc(sizeof(PQExpBufferData));
+					initPQExpBuffer(msgbuf);
+					while (1) {
+						if (pqGets_append(msgbuf, conn))
+							break;
+					}
+
+					int tempfile = open("/tmp/token_dump", O_CREAT | O_WRONLY, 0666);
+					char *token = malloc(128);
+					memset(token, 0, 128);
+					snprintf(token, 128, "%d\n", conn->result->token);
+					write(tempfile, token, strlen(token));
+					write(tempfile, msgbuf->data, msgbuf->len);
+					close(tempfile);
+					free(msgbuf);
+					free(token);
+					break;
+#endif
 #ifndef FRONTEND
 				case 'j':
 					/*

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -247,6 +247,8 @@ struct pg_result
 	/* GPDB: number of processed tuples for each AO partition */
 	int			naotupcounts;
 	PQaoRelTupCount *aotupcounts;
+	/* GPDB: token for multi process fetch */
+	int32       token;
 };
 
 /* PGAsyncStatusType defines the state of the query-execution state machine */


### PR DESCRIPTION
Add a new libpq command type 'm', which transfers an int32 token number
and several postmasters' connection info, like:

```
12345
mdw:5432
sdw1:40000
sdw2:40001
sdw3:40002
```

Client needs to get an int32, then tries to get as much string as
possible.